### PR TITLE
fix typo issue for running docker-compose.dev.yml

### DIFF
--- a/{{cookiecutter.project_name}}/template_minimal/docker-compose.dev.yml
+++ b/{{cookiecutter.project_name}}/template_minimal/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 # Database + Webserver (under http, for testing setup on localhost:80)
 #
-# docker-compose up -f docker-compose.dev.yml -d
+# docker-compose -f docker-compose.dev.yml up -d
 #
 
 services:


### PR DESCRIPTION
fix typo issue: #11  for running `docker-compose.dev.yml`


