### PR TITLE
Fixed Ruff linter defaulting to python3.8

### DIFF
--- a/{{cookiecutter.project_name}}/app/core/config.py
+++ b/{{cookiecutter.project_name}}/app/core/config.py
@@ -21,11 +21,11 @@ See https://pydantic-docs.helpmanual.io/usage/settings/
 Note, complex types like lists are read as json-encoded strings.
 """
 
+import tomllib
 from functools import cached_property
 from pathlib import Path
 from typing import Literal
 
-import tomllib
 from pydantic import AnyHttpUrl, EmailStr, PostgresDsn, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -44,6 +44,7 @@ minversion = "6.0"
 testpaths = ["app/tests"]
 
 [tool.ruff]
+target-version = "py312"
 # pycodestyle, pyflakes, isort, pylint, pyupgrade
 select = ["E", "W", "F", "I", "PL", "UP"]
 ignore = ["E501"]


### PR DESCRIPTION
[Ruff currently defaults to linting code as if it was Python 3.8](https://docs.astral.sh/ruff/settings/#target-version), hence the tomllib import being moved in commit 7edb31c.

It can be specified with `requires-python = ">= 3.12"` in the `[project]` section of pyproject.toml, but since you are not using that section I used the Ruff specific option.