### PR TITLE
Remove trailing "/" when creating backend origin CORS urls

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ app.include_router(api_router)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-        str(origin) for origin in get_settings().security.backend_cors_origins
+        str(origin).rstrip("/") for origin in get_settings().security.backend_cors_origins
     ],
     allow_credentials=True,
     allow_methods=["*"],


### PR DESCRIPTION
The backend_cors_origin is a list[AnyHttpUrl] which, when transformed to str via str(origin), adds a trailing slash at the end of the url. This messes up CORS (at least in google chrome)